### PR TITLE
Fixing memory leak

### DIFF
--- a/PhotoSelectAndCrop/ContentView.swift
+++ b/PhotoSelectAndCrop/ContentView.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct ContentView: View {
-    
+
+    @StateObject var orientation = DeviceOrientation()
+
     @State private var isShowingPhotoSelectionSheet = false
 
     @State private var originalImage: UIImage?
@@ -50,7 +52,7 @@ struct ContentView: View {
         .statusBar(hidden: isShowingPhotoSelectionSheet)
         .fullScreenCover(isPresented: $isShowingPhotoSelectionSheet, onDismiss: loadImage) {
             ImageMoveAndScaleSheet(originalImage: $originalImage, originalPosition: $position, originalZoom: $zoom, processedImage: $inputImage)
-                .environmentObject(DeviceOrientation())
+                .environmentObject(orientation)
         }
     }
     


### PR DESCRIPTION
Saw your reddit post and decided to have a gander at the code and noticed a weird looking usage of environment object. I'm not a SwiftUI expert but the usage looked strange to me. The fix is to create the DeviceOrientation as a member of the ContentView instead and pass a reference to the new member in your .environmentObject(_:).  